### PR TITLE
chore: prepare v1.0.0 release

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,38 +1,36 @@
 ---
 name: Bug report
-about: Create a report to help us improve
-title: ''
-labels: ''
-assignees: ''
-
+about: Report incorrect behavior, errors, or documentation problems
+title: ""
+labels: bug
+assignees: ""
 ---
 
-**Describe the bug**
-A clear and concise description of what the bug is.
+## Summary
 
-**To Reproduce**
-Steps to reproduce the behavior:
-1. Go to '...'
-2. Click on '....'
-3. Scroll down to '....'
-4. See error
+<!-- What is wrong? -->
 
-**Expected behavior**
-A clear and concise description of what you expected to happen.
+## Minimal Reproduction
 
-**Screenshots**
-If applicable, add screenshots to help explain your problem.
+```python
+# Smallest code example that reproduces the issue
+```
 
-**Desktop (please complete the following information):**
- - OS: [e.g. iOS]
- - Browser [e.g. chrome, safari]
- - Version [e.g. 22]
+## Expected Behavior
 
-**Smartphone (please complete the following information):**
- - Device: [e.g. iPhone6]
- - OS: [e.g. iOS8.1]
- - Browser [e.g. stock browser, safari]
- - Version [e.g. 22]
+<!-- What should happen? -->
 
-**Additional context**
-Add any other context about the problem here.
+## Actual Behavior
+
+<!-- Include the full traceback or warning text when relevant. -->
+
+## Environment
+
+- nonconform version:
+- Python version:
+- OS:
+- Relevant dependencies, detectors, or optional extras:
+
+## Context
+
+<!-- Data assumptions, detector family, score polarity, calibration strategy, or links to related work if relevant. -->

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,20 +1,27 @@
 ---
 name: Feature request
-about: Suggest an idea for this project
-title: ''
-labels: ''
-assignees: ''
-
+about: Propose a focused API, documentation, method, or scope extension
+title: ""
+labels: enhancement
+assignees: ""
 ---
 
-**Is your feature request related to a problem? Please describe.**
-A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
+## Use Case
 
-**Describe the solution you'd like**
-A clear and concise description of what you want to happen.
+<!-- What workflow does this improve or enable? -->
 
-**Describe alternatives you've considered**
-A clear and concise description of any alternative solutions or features you've considered.
+## Proposed Change
 
-**Additional context**
-Add any other context or screenshots about the feature request here.
+<!-- Describe the smallest useful change, method, or approach. -->
+
+## API or Statistical Impact
+
+<!-- Note public API changes, validity claims, p-value/FDR behavior, weighting, calibration, or metric implications. -->
+
+## References or Prior Art
+
+<!-- Link relevant papers, implementations, detector libraries, or CAD/conformal/FDR discussions when applicable. -->
+
+## Alternatives
+
+<!-- Existing workarounds or reasons they are insufficient. -->

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,24 @@
+## Summary
+
+<!-- What changed, and why? -->
+
+## Scope
+
+<!-- Keep this focused. Note any intentionally excluded follow-up work. -->
+
+## API and Statistical Impact
+
+<!-- Public API changes? Statistical-core changes? Validity-claim changes? If none, say so. -->
+
+## Validation
+
+<!-- Exact commands run, for example:
+uv run ruff format .
+uv run ruff check . --fix
+uv run pytest
+uv run mkdocs build -f docs/mkdocs.yml
+-->
+
+## References
+
+<!-- Related issues, papers, detector libraries, or implementation notes. -->

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,13 +1,16 @@
-# Pre-1.0 Break-First Policy
+# v1 Compatibility Policy
 
-This project is pre-release. Backward compatibility is currently **not** a constraint.
+This project has reached `v1.0.0`. Backward compatibility is now a constraint
+for documented public APIs and statistical validity claims.
 
-- Prefer clean-break solutions over compatibility layers.
-- Prefer structural refactors over incremental patching when they improve long-term design.
-- Remove obsolete APIs instead of maintaining transitional shims.
-- Document intentional breaking changes explicitly.
-
-At `v1.0.0`, remove this section and switch to strict backward-compatibility policy.
+- Prefer additive public APIs over changing or removing existing public APIs.
+- Treat `nonconform.__all__` and public module `__all__` exports as compatibility
+  contracts.
+- Keep `nonconform._internal` private and out of user-facing docs/examples.
+- Breaking public API changes require a major-version plan, migration notes, and
+  explicit release documentation.
+- Statistical-core behavior changes require explicit before/after rationale and
+  validation evidence.
 
 # Decision Hierarchy
 

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,128 +1,32 @@
-# Contributor Covenant Code of Conduct
+# Code of Conduct
 
-## Our Pledge
+This project expects professional conduct in issues, pull requests, reviews,
+and project-owned communication channels.
 
-We as members, contributors, and leaders pledge to make participation in our
-community a harassment-free experience for everyone, regardless of age, body
-size, visible or invisible disability, ethnicity, sex characteristics, gender
-identity and expression, level of experience, education, socio-economic status,
-nationality, personal appearance, race, religion, or sexual identity
-and orientation.
+## Expected Behavior
 
-We pledge to act and interact in ways that contribute to an open, welcoming,
-diverse, inclusive, and healthy community.
+- Discuss technical disagreements on their merits.
+- Be direct without personal attacks.
+- Give actionable feedback.
+- Respect maintainer decisions on scope, API stability, and statistical claims.
+- Credit relevant prior work when it informs a contribution.
 
-## Our Standards
+## Unacceptable Behavior
 
-Examples of behavior that contributes to a positive environment for our
-community include:
+- Harassment, threats, or sustained hostile behavior.
+- Discriminatory or sexualized language.
+- Personal attacks, insults, or deliberate disruption.
+- Publishing private information without permission.
+- Repeatedly ignoring maintainer requests to stop a behavior.
 
-* Demonstrating empathy and kindness toward other people
-* Being respectful of differing opinions, viewpoints, and experiences
-* Giving and gracefully accepting constructive feedback
-* Accepting responsibility and apologizing to those affected by our mistakes,
-  and learning from the experience
-* Focusing on what is best not just for us as individuals, but for the
-  overall community
+## Reporting
 
-Examples of unacceptable behavior include:
+Report conduct issues to <oliver.hennhoefer@mail.de>.
 
-* The use of sexualized language or imagery, and sexual attention or
-  advances of any kind
-* Trolling, insulting or derogatory comments, and personal or political attacks
-* Public or private harassment
-* Publishing others' private information, such as a physical or email
-  address, without their explicit permission
-* Other conduct which could reasonably be considered inappropriate in a
-  professional setting
-
-## Enforcement Responsibilities
-
-Community leaders are responsible for clarifying and enforcing our standards of
-acceptable behavior and will take appropriate and fair corrective action in
-response to any behavior that they deem inappropriate, threatening, offensive,
-or harmful.
-
-Community leaders have the right and responsibility to remove, edit, or reject
-comments, commits, code, wiki edits, issues, and other contributions that are
-not aligned to this Code of Conduct, and will communicate reasons for moderation
-decisions when appropriate.
-
-## Scope
-
-This Code of Conduct applies within all community spaces, and also applies when
-an individual is officially representing the community in public spaces.
-Examples of representing our community include using an official e-mail address,
-posting via an official social media account, or acting as an appointed
-representative at an online or offline event.
+Reports should include relevant links, screenshots, or context when available.
+Reports will be reviewed privately.
 
 ## Enforcement
 
-Instances of abusive, harassing, or otherwise unacceptable behavior may be
-reported to the community leaders responsible for enforcement at
-oliver.hennhoefer@mail.de.
-All complaints will be reviewed and investigated promptly and fairly.
-
-All community leaders are obligated to respect the privacy and security of the
-reporter of any incident.
-
-## Enforcement Guidelines
-
-Community leaders will follow these Community Impact Guidelines in determining
-the consequences for any action they deem in violation of this Code of Conduct:
-
-### 1. Correction
-
-**Community Impact**: Use of inappropriate language or other behavior deemed
-unprofessional or unwelcome in the community.
-
-**Consequence**: A private, written warning from community leaders, providing
-clarity around the nature of the violation and an explanation of why the
-behavior was inappropriate. A public apology may be requested.
-
-### 2. Warning
-
-**Community Impact**: A violation through a single incident or series
-of actions.
-
-**Consequence**: A warning with consequences for continued behavior. No
-interaction with the people involved, including unsolicited interaction with
-those enforcing the Code of Conduct, for a specified period of time. This
-includes avoiding interactions in community spaces as well as external channels
-like social media. Violating these terms may lead to a temporary or
-permanent ban.
-
-### 3. Temporary Ban
-
-**Community Impact**: A serious violation of community standards, including
-sustained inappropriate behavior.
-
-**Consequence**: A temporary ban from any sort of interaction or public
-communication with the community for a specified period of time. No public or
-private interaction with the people involved, including unsolicited interaction
-with those enforcing the Code of Conduct, is allowed during this period.
-Violating these terms may lead to a permanent ban.
-
-### 4. Permanent Ban
-
-**Community Impact**: Demonstrating a pattern of violation of community
-standards, including sustained inappropriate behavior,  harassment of an
-individual, or aggression toward or disparagement of classes of individuals.
-
-**Consequence**: A permanent ban from any sort of public interaction within
-the community.
-
-## Attribution
-
-This Code of Conduct is adapted from the [Contributor Covenant][homepage],
-version 2.0, available at
-https://www.contributor-covenant.org/version/2/0/code_of_conduct.html.
-
-Community Impact Guidelines were inspired by [Mozilla's code of conduct
-enforcement ladder](https://github.com/mozilla/diversity).
-
-[homepage]: https://www.contributor-covenant.org
-
-For answers to common questions about this code of conduct, see the FAQ at
-https://www.contributor-covenant.org/faq. Translations are available at
-https://www.contributor-covenant.org/translations.
+Maintainers may edit or remove comments, close issues, reject contributions,
+block accounts, or take other reasonable action to protect the project.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,95 +1,82 @@
 # Contributing
 
-Thank you for your interest in contributing to this project! We welcome contributions from the community.
+Contributions are useful when they improve the library's correctness, scope,
+usability, documentation, or interoperability.
 
-This project uses [uv](https://docs.astral.sh/uv/) for dependency management and [ruff](https://docs.astral.sh/ruff/) for formatting and linting.
-
-## Getting Started
-
-1. Fork the repository on GitHub
-2. Clone your fork locally:
-   ```bash
-   git clone https://github.com/OliverHennhoefer/nonconform.git
-   cd nonconform
-   ```
-3. Create a new branch for your changes:
-   ```bash
-   git checkout -b feature/your-feature-name
-   ```
+Project-relevant contributions include bug reports, focused fixes, tests,
+documentation corrections, detector compatibility notes, examples, and new
+methods or approaches for conformal anomaly detection (CAD), conformal
+inference, FDR control, covariate-shift workflows, or related detector
+interfaces.
 
 ## Development Setup
 
-1. Install [uv](https://docs.astral.sh/uv/) if you haven't already:
-   ```bash
-   curl -LsSf https://astral.sh/uv/install.sh | sh  # On Windows: irm https://astral.sh/uv/install.ps1 | iex
-   ```
+Prerequisites:
 
-2. Sync the project and install dependencies:
-   ```bash
-   uv sync
-   ```
+- Python 3.12 or newer
+- Git
+- [uv](https://docs.astral.sh/uv/)
 
-3. The virtual environment will be automatically created and managed by uv
+Clone and install:
 
-4. Install ``nonconform`` from the local repository.
-   ```bash
-    uv pip install -e .[all] --upgrade
-   ```
+```bash
+git clone https://github.com/OliverHennhoefer/nonconform.git
+cd nonconform
+uv sync --group dev
+uv pip install -e ".[all]"
+```
 
-## Making Changes
+Optional pre-commit setup:
 
-1. Make your changes in your feature branch
-2. Add tests for any new functionality
-3. Ensure all tests pass:
-   ```bash
-   uv run pytest
-   ```
-4. Format and check code style:
-   ```bash
-   uv run ruff format .
-   uv run ruff check .
-   ```
+```bash
+uv run pre-commit install
+```
 
-## Code Style
+## Before Opening a Pull Request
 
-- Follow [PEP 8](https://pep8.org/) style guidelines (enforced by ruff)
-- Use meaningful variable and function names
-- Add docstrings to functions and classes
-- Keep functions focused and concise
-- Write clear commit messages
-- Run `uv run ruff format .` before committing to ensure consistent formatting
+Keep changes focused. A pull request should have one clear purpose.
 
-## Testing
+Run the checks that match your change:
 
-- Write tests for new features and bug fixes
-- Ensure all existing tests pass before submitting with `uv run pytest`
-- Aim for good test coverage of your changes
-- Run `uv run pytest --cov` to check coverage (if configured)
+```bash
+uv run ruff format .
+uv run ruff check . --fix
+uv run pytest
+```
 
-## Submitting a Pull Request
+If documentation under `docs/` changed, also run:
 
-1. Push your changes to your fork:
-   ```bash
-   git push origin feature/your-feature-name
-   ```
+```bash
+uv run mkdocs build -f docs/mkdocs.yml
+```
 
-2. Open a pull request on GitHub with:
-   - A clear title and description
-   - Reference to any related issues
-   - Summary of changes made
-   - Any breaking changes highlighted
+When changes affect p-values, FDR control, weighting, calibration,
+aggregation, metrics, or validity claims, include tests that cover the
+statistical behavior and explain the before/after rationale in the pull request.
 
-3. Wait for review and address any feedback
+## API Compatibility
 
-## Reporting Issues
+nonconform is a v1 project. Public APIs should remain stable unless a breaking
+change is intentional and explicitly justified.
 
-When reporting issues, please include:
-- A clear description of the problem
-- Steps to reproduce the issue
-- Expected vs actual behavior
-- Your environment (Python version, OS, etc.)
-- Any relevant error messages or logs
+Treat these as public contracts:
 
-## Questions?
+- root exports in `nonconform.__all__`
+- public module `__all__` exports
+- documented constructor arguments, methods, properties, enum values, and
+  dataclass fields
 
-Feel free to open an issue for questions or discussions about contributions.
+Implementation details under `nonconform._internal` are private.
+
+## Issues
+
+Bug reports should include:
+
+- a minimal reproducible example
+- expected and actual behavior
+- Python, operating system, and dependency versions
+- full traceback or warning text when relevant
+
+Feature requests should describe the use case, the proposed method or approach,
+the statistical or API impact, and any relevant literature or detector family
+when applicable.

--- a/README.md
+++ b/README.md
@@ -160,7 +160,7 @@ class MyDetector:
     def set_params(self, **params) -> Self: ...
 ```
 
-For custom detectors, either set `score_polarity` explicitly (`"higher_is_anomalous"` in most cases), or omit it to use the pre-release default behavior. Use `score_polarity="auto"` only when you want strict detector-family validation.
+For custom detectors, either set `score_polarity` explicitly (`"higher_is_anomalous"` in most cases), or omit it to use the default score-polarity policy. Use `score_polarity="auto"` only when you want strict detector-family validation.
 
 See [Detector Compatibility](https://oliverhennhoefer.github.io/nonconform/user_guide/detector_compatibility/) for details and examples.
 

--- a/README.md
+++ b/README.md
@@ -31,6 +31,23 @@ and the relevant multiple-testing assumptions.
 | Sequential monitoring | Exchangeability martingales (`PowerMartingale`, `SimpleMixtureMartingale`, `SimpleJumperMartingale`) | [Exchangeability Martingales](https://oliverhennhoefer.github.io/nonconform/user_guide/exchangeability_martingales/) |
 | Custom detector integration | Support for any detector implementing the `AnomalyDetector` protocol | [Detector Compatibility](https://oliverhennhoefer.github.io/nonconform/user_guide/detector_compatibility/) |
 
+## Citation
+
+If you use **nonconform** in academic work, reports, or other published
+material, please cite the accompanying paper:
+
+```bibtex
+@misc{hennhöfer2026conformalanomalydetectionpython,
+      title={Conformal Anomaly Detection in Python: Moving Beyond Heuristic Thresholds with 'nonconform'},
+      author={Oliver Hennhöfer and Maximilian Kirsch and Christine Preisach},
+      year={2026},
+      eprint={2605.13642},
+      archivePrefix={arXiv},
+      primaryClass={stat.ML},
+      url={https://arxiv.org/abs/2605.13642},
+}
+```
+
 ## Getting Started
 
 Installation via [PyPI](https://pypi.org/project/nonconform/):

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,22 +1,25 @@
 # Security Policy
 
-## Reporting a Vulnerability
-If you discover a security issue, please report it responsibly.
-
-- **Contact:** [oliver.hennhoefer@mail.de]
-- **Response Time:** We aim to acknowledge reports within 14 days.
-
 ## Supported Versions
-Security updates are provided for the latest release only.
+
+Security fixes target the latest released version.
 
 | Version | Supported |
-|----------|------------|
-| latest   | ✅ |
-| older    | ❌ |
+| --- | --- |
+| Latest release | Yes |
+| Older releases | No |
 
-## Disclosure Policy
-- Do not publicly disclose vulnerabilities before a fix is released.
-- Provide enough detail to reproduce the issue safely.
+## Reporting a Vulnerability
 
-## Additional Notes
-This project currently has limited security review. Use at your own risk.
+Report security issues by email: <oliver.hennhoefer@mail.de>.
+
+Include enough detail to reproduce the issue safely. Do not disclose the issue
+publicly until a fix is available or disclosure has been coordinated.
+
+Expected response: acknowledgement within 14 days.
+
+## Scope
+
+This project is a scientific Python library. Security review is limited. Reports
+about dependency-chain exposure, unsafe deserialization, arbitrary code
+execution, credential leakage, or packaging/release integrity are in scope.

--- a/docs/README.md
+++ b/docs/README.md
@@ -159,7 +159,7 @@ class MyDetector:
     def set_params(self, **params) -> Self: ...
 ```
 
-For custom detectors, either set `score_polarity` explicitly (`"higher_is_anomalous"` in most cases), or omit it to use the pre-release default behavior. Use `score_polarity="auto"` only when you want strict detector-family validation.
+For custom detectors, either set `score_polarity` explicitly (`"higher_is_anomalous"` in most cases), or omit it to use the default score-polarity policy. Use `score_polarity="auto"` only when you want strict detector-family validation.
 
 For strict inductive conformal/FDR pipelines, avoid batch-adaptive PyOD
 detectors with non-frozen score maps (for example `ECOD` and `COPOD`, which are

--- a/docs/README.md
+++ b/docs/README.md
@@ -30,6 +30,23 @@ and the relevant multiple-testing assumptions.
 | Sequential monitoring | Exchangeability martingales (`PowerMartingale`, `SimpleMixtureMartingale`, `SimpleJumperMartingale`) | [Exchangeability Martingales](https://oliverhennhoefer.github.io/nonconform/user_guide/exchangeability_martingales/) |
 | Custom detector integration | Support for protocol-compliant detectors (with strict-inductive caveats for blocked PyOD models) | [Detector Compatibility](https://oliverhennhoefer.github.io/nonconform/user_guide/detector_compatibility/) |
 
+## Citation
+
+If you use **nonconform** in academic work, reports, or other published
+material, please cite the accompanying paper:
+
+```bibtex
+@misc{hennhöfer2026conformalanomalydetectionpython,
+      title={Conformal Anomaly Detection in Python: Moving Beyond Heuristic Thresholds with 'nonconform'},
+      author={Oliver Hennhöfer and Maximilian Kirsch and Christine Preisach},
+      year={2026},
+      eprint={2605.13642},
+      archivePrefix={arXiv},
+      primaryClass={stat.ML},
+      url={https://arxiv.org/abs/2605.13642},
+}
+```
+
 ## Getting Started
 
 Installation via [PyPI](https://pypi.org/project/nonconform/):

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -79,6 +79,7 @@ nav:
     - FDR Control: examples/fdr_control.md
   - API Reference:
     - Overview: api/index.md
+    - Stability Contract: api/stability.md
     - Common Workflows: api/common_workflows.md
   - Contributing: contributing.md
 

--- a/docs/source/api/index.md
+++ b/docs/source/api/index.md
@@ -7,6 +7,9 @@ Complete API documentation for all nonconform modules and classes.
 If you are looking for task-oriented call sequences, start with
 [Common Workflows](common_workflows.md).
 
+For the v1 public compatibility contract, see
+[API Stability](stability.md).
+
 ## Detector
 
 ::: nonconform.detector

--- a/docs/source/api/stability.md
+++ b/docs/source/api/stability.md
@@ -1,0 +1,40 @@
+# API Stability
+
+nonconform 1.x treats public API stability as a release constraint.
+
+## Stable Public Surface
+
+The compatibility contract is defined by:
+
+- `nonconform.__all__`, the intentionally small root import surface.
+- `__all__` in public modules such as `nonconform.scoring`,
+  `nonconform.resampling`, `nonconform.weighting`, `nonconform.fdr`,
+  `nonconform.metrics`, `nonconform.martingales`, `nonconform.structures`,
+  `nonconform.adapters`, and `nonconform.enums`.
+- Public constructor parameters, public methods and properties, dataclass
+  fields, enum members, and documented string literal values.
+
+Symbols under `nonconform._internal` are private implementation details and are
+not covered by the compatibility contract.
+
+## Change Policy
+
+Patch and minor releases should preserve documented public behavior. Prefer
+additive APIs over changing or removing existing public symbols.
+
+Breaking public API changes require a major-version release plan, release notes,
+and documentation updates. Statistical-core behavior changes require explicit
+before/after rationale because they can change validity claims even when the
+Python signature is unchanged.
+
+## Score Polarity Defaults
+
+If `score_polarity` is omitted, the v1 default policy is:
+
+- known scikit-learn normality-scoring detectors use `"higher_is_normal"`;
+- PyOD detectors use `"higher_is_anomalous"`;
+- custom detectors outside recognized families use `"higher_is_anomalous"`.
+
+Use `score_polarity="auto"` when strict detector-family validation is desired;
+it raises for custom detectors outside recognized PyOD and known scikit-learn
+families.

--- a/docs/source/contributing.md
+++ b/docs/source/contributing.md
@@ -1,147 +1,70 @@
-# Contributing to nonconform
+# Contributing
 
-We welcome contributions to nonconform! This guide will help you get started.
+Contributions should improve the library's correctness, scope, usability,
+documentation, or interoperability.
 
-## Types of Contributions
+Useful contributions include focused bug fixes, tests, documentation
+corrections, detector compatibility notes, examples, and new methods or
+approaches for conformal anomaly detection, conformal inference, FDR control,
+covariate-shift workflows, or related detector interfaces.
 
-### Bug Reports
-- Use the GitHub issue tracker
-- Include minimal reproducible examples
-- Specify your environment (Python version, OS, etc.)
+## Setup
 
-### Feature Requests
-- Describe the use case clearly
-- Explain how it fits with the project's goals
-- Consider proposing an implementation approach
+```bash
+git clone https://github.com/OliverHennhoefer/nonconform.git
+cd nonconform
+uv sync --group dev
+uv pip install -e ".[all]"
+```
 
-### Code Contributions
-- Bug fixes
-- New conformalization strategies
-- Performance improvements
-- Documentation improvements
+Optional pre-commit hooks:
 
-### Documentation
-- Fix typos or unclear explanations
-- Add examples or tutorials
-- Improve API documentation
+```bash
+uv run pre-commit install
+```
 
-## Development Setup
+## Checks
 
-### Prerequisites
-- Python 3.12 or higher
-- Git
-- [uv](https://docs.astral.sh/uv/) (Python package manager)
+Run the checks that match the change:
 
-### Setup Instructions
+```bash
+uv run ruff format .
+uv run ruff check . --fix
+uv run pytest
+```
 
-1. **Fork and clone the repository**
-   ```bash
-   git clone https://github.com/yourusername/nonconform.git
-   cd nonconform
-   ```
+For documentation changes:
 
-2. **Install dependencies and setup development environment**
-   ```bash
-   # Install project + development dependencies
-   uv sync --group dev
-   ```
+```bash
+uv run mkdocs build -f docs/mkdocs.yml
+```
 
-3. **Setup pre-commit hooks**
-   ```bash
-   uv run pre-commit install
-   ```
+## Pull Requests
 
-4. **Run tests to verify setup**
-   ```bash
-   uv run pytest
-   ```
+Keep pull requests focused and include:
 
-## Development Workflow
+- what changed and why
+- exact validation commands run
+- public API impact, if any
+- statistical-core impact, if any
+- relevant papers, detector libraries, or implementation references when useful
 
-### Before Making Changes
+Changes to p-values, FDR control, weighting, calibration, aggregation, metrics,
+or validity claims need tests and an explicit before/after rationale.
 
-1. **Create a new branch**
-   ```bash
-   git checkout -b feature/your-feature-name
-   # or
-   git checkout -b fix/issue-description
-   ```
+## API Stability
 
-2. **Sync with upstream**
-   ```bash
-   git remote add upstream https://github.com/original/nonconform.git
-   git fetch upstream
-   git rebase upstream/main
-   ```
+nonconform is a v1 project. Public APIs should remain stable unless a breaking
+change is intentional and documented.
 
-### Making Changes
+Public contracts include root exports, public module `__all__` exports,
+documented constructor arguments, methods, properties, enum values, and
+dataclass fields. `nonconform._internal` is private.
 
-1. **Write tests first** (TDD approach recommended)
-   ```bash
-   # Add tests in tests/ and run a focused subset while iterating
-   uv run pytest tests/unit/test_your_feature.py -q
-   ```
+## Issues
 
-2. **Implement your changes**
-   - Follow the existing code style
-   - Add docstrings to new functions/classes
-   - Keep commits atomic and well-described
+Bug reports should include a minimal reproducible example, expected and actual
+behavior, environment details, and tracebacks or warnings when relevant.
 
-3. **Run the full test suite**
-   ```bash
-   uv run pytest
-   ```
-
-4. **Check code quality**
-   ```bash
-   # Format code and fix linting issues
-   uv run ruff format .
-   uv run ruff check . --fix
-
-   # Or run all pre-commit hooks
-   uv run pre-commit run --all-files
-   ```
-
-### Documentation
-
-1. **Update docstrings**
-   - Use Google style docstrings
-   - Include examples where helpful
-   - Document all parameters and return values
-
-2. **Update user documentation**
-   - Add new features to appropriate guides
-   - Update examples if needed
-   - Test documentation builds locally
-
-3. **Build documentation locally**
-   ```bash
-   uv run mkdocs serve -f docs/mkdocs.yml
-   # Open http://127.0.0.1:8000 in browser
-   ```
-
-### Submitting Changes
-
-1. **Commit your changes**
-   ```bash
-   git add .
-   git commit -m "feat: add weighted conformal p-values for covariate shift"
-   ```
-
-2. **Push to your fork**
-   ```bash
-   git push origin feature/your-feature-name
-   ```
-
-3. **Create a pull request**
-   - Use a clear, descriptive title
-   - Explain what changes you made and why
-   - Reference any related issues
-   - Include tests and documentation updates
-
-## Code Style Guidelines
-
-### Python Code Style
-- Follow PEP 8
-- Use Ruff for formatting and linting (replaces Black, isort, flake8)
-- Use Google-style docstrings
+Feature requests should describe the workflow, proposed method or approach,
+statistical or API impact, and relevant prior work when applicable.

--- a/docs/source/index.md
+++ b/docs/source/index.md
@@ -50,6 +50,23 @@ Use this library when you need:
 - Multiple testing correction
 - Calibrated uncertainty for downstream workflows
 
+## Citation
+
+If you use **nonconform** in academic work, reports, or other published
+material, please cite the accompanying paper:
+
+```bibtex
+@misc{hennhöfer2026conformalanomalydetectionpython,
+      title={Conformal Anomaly Detection in Python: Moving Beyond Heuristic Thresholds with 'nonconform'},
+      author={Oliver Hennhöfer and Maximilian Kirsch and Christine Preisach},
+      year={2026},
+      eprint={2605.13642},
+      archivePrefix={arXiv},
+      primaryClass={stat.ML},
+      url={https://arxiv.org/abs/2605.13642},
+}
+```
+
 ## Guarantee Scope
 
 nonconform does not make a weak detector "correct." It calibrates detector

--- a/nonconform/__init__.py
+++ b/nonconform/__init__.py
@@ -42,7 +42,7 @@ Examples:
     ... )
 """
 
-__version__ = "0.98.76"
+__version__ = "1.0.0"
 __author__ = "Oliver Hennhoefer"
 __email__ = "oliver.hennhoefer@mail.de"
 

--- a/nonconform/adapters.py
+++ b/nonconform/adapters.py
@@ -145,7 +145,7 @@ def _is_known_sklearn_normality_detector(detector: Any) -> bool:
 def resolve_implicit_score_polarity(detector: Any) -> ScorePolarity:
     """Resolve score polarity when users omit score_polarity.
 
-    This pre-release default favors low-friction custom detector onboarding while
+    The default favors low-friction custom detector onboarding while
     preserving safe behavior for known detector families:
     - Known sklearn normality detectors -> HIGHER_IS_NORMAL
     - PyOD detectors -> HIGHER_IS_ANOMALOUS

--- a/nonconform/py.typed
+++ b/nonconform/py.typed
@@ -1,0 +1,1 @@
+# Marker file for PEP 561 type information.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ classifiers = [
     "Programming Language :: Python :: 3.13",
     "License :: OSI Approved :: BSD License",
     "Operating System :: OS Independent",
-    "Development Status :: 4 - Beta",
+    "Development Status :: 5 - Production/Stable",
     "Intended Audience :: Science/Research",
     "Intended Audience :: Developers",
     "Topic :: Scientific/Engineering :: Artificial Intelligence",
@@ -46,7 +46,7 @@ path = "nonconform/__init__.py"
 
 # pyproject.toml
 [tool.hatch.build.targets.sdist]
-include = ["nonconform", "README.md", "LICENSE", "pyproject.toml"]
+include = ["nonconform", "README.md", "docs/README.md", "LICENSE", "pyproject.toml"]
 exclude = [".uv-cache", ".venv", "dist", "docs/site", ".pytest_cache", ".ruff_cache", "__pycache__"]
 
 [tool.hatch.build.targets.wheel]
@@ -69,7 +69,12 @@ probabilistic = [
     "kdepy>=1.1.12",
 ]
 all = [
-    "nonconform[pyod,data,fdr,probabilistic]"
+    "pyod==2.0.7",
+    "oddball>=1.3.0",
+    "pyarrow>=16.1.0",
+    "online-fdr>=0.0.3",
+    "optuna>=4.5.0",
+    "kdepy>=1.1.12",
 ]
 
 [dependency-groups]

--- a/tests/unit/test_public_api_surface.py
+++ b/tests/unit/test_public_api_surface.py
@@ -1,4 +1,6 @@
+import importlib
 from enum import Enum
+from pathlib import Path
 
 import pytest
 
@@ -38,9 +40,85 @@ REMOVED_ROOT_SYMBOLS = [
     "weighted_false_discovery_control",
 ]
 
+PUBLIC_MODULE_EXPORTS = {
+    "nonconform.adapters": [
+        "PYOD_AVAILABLE",
+        "PyODAdapter",
+        "ScorePolarityAdapter",
+        "adapt",
+        "apply_score_polarity",
+        "parse_score_polarity",
+        "resolve_implicit_score_polarity",
+        "resolve_score_polarity",
+    ],
+    "nonconform.detector": [
+        "BaseConformalDetector",
+        "ConformalDetector",
+    ],
+    "nonconform.enums": [
+        "ConformalMode",
+        "Distribution",
+        "Kernel",
+        "Pruning",
+        "ScorePolarity",
+        "TieBreakMode",
+    ],
+    "nonconform.fdr": [
+        "Pruning",
+        "weighted_false_discovery_control",
+        "weighted_false_discovery_control_from_arrays",
+    ],
+    "nonconform.martingales": [
+        "AlarmConfig",
+        "BaseMartingale",
+        "MartingaleState",
+        "PowerMartingale",
+        "SimpleJumperMartingale",
+        "SimpleMixtureMartingale",
+    ],
+    "nonconform.metrics": [
+        "aggregate",
+        "false_discovery_rate",
+        "statistical_power",
+    ],
+    "nonconform.resampling": [
+        "BaseStrategy",
+        "CrossValidation",
+        "JackknifeBootstrap",
+        "Split",
+    ],
+    "nonconform.scoring": [
+        "BaseEstimation",
+        "ConditionalEmpirical",
+        "Empirical",
+        "Kernel",
+        "Probabilistic",
+        "calculate_p_val",
+        "calculate_weighted_p_val",
+    ],
+    "nonconform.structures": [
+        "AnomalyDetector",
+        "ConformalResult",
+    ],
+    "nonconform.weighting": [
+        "EPSILON",
+        "BaseWeightEstimator",
+        "BootstrapBaggedWeightEstimator",
+        "IdentityWeightEstimator",
+        "ProbabilisticClassifier",
+        "SklearnWeightEstimator",
+        "forest_weight_estimator",
+        "logistic_weight_estimator",
+    ],
+}
+
 
 def test_root_all_is_exact_curated_surface():
     assert nonconform.__all__ == CURATED_ROOT_EXPORTS
+
+
+def test_package_declares_pep_561_type_marker():
+    assert Path(nonconform.__file__).with_name("py.typed").is_file()
 
 
 def test_star_import_exposes_only_curated_symbols():
@@ -59,6 +137,34 @@ def test_removed_root_symbols_are_not_attributes():
 def test_removed_root_import_raises_import_error(symbol: str):
     with pytest.raises(ImportError, match=symbol):
         exec(f"from nonconform import {symbol}", {})
+
+
+@pytest.mark.parametrize(
+    ("module_name", "expected_exports"),
+    PUBLIC_MODULE_EXPORTS.items(),
+)
+def test_public_module_all_is_exact_contract(
+    module_name: str, expected_exports: list[str]
+):
+    module = importlib.import_module(module_name)
+
+    assert module.__all__ == expected_exports
+    for symbol in expected_exports:
+        assert hasattr(module, symbol)
+
+
+@pytest.mark.parametrize(
+    ("module_name", "expected_exports"),
+    PUBLIC_MODULE_EXPORTS.items(),
+)
+def test_public_module_star_import_matches_contract(
+    module_name: str, expected_exports: list[str]
+):
+    namespace: dict[str, object] = {}
+    exec(f"from {module_name} import *", namespace)
+
+    exported = {name for name in namespace if not name.startswith("__")}
+    assert exported == set(expected_exports)
 
 
 def test_enums_module_exports_expected_symbols():


### PR DESCRIPTION
- bump package metadata to v1.0.0 and Production/Stable
- replace pre-1.0 project policy with v1 API compatibility guidance
- add API stability documentation and public export contract tests
- add PEP 561 py.typed marker
- fix release packaging metadata for sdist README and all extras