### PR TITLE
Count tied calibration mass in calculate_weighted_p_val's classical branch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.1.1] - 2026-08-19
+
+### Changed
+
+- Classical weighted empirical p-values include calibration mass tied with
+  the test score, aligning deterministic weighted and unweighted empirical
+  p-values for discrete scores.
+- Seeded randomized WCS pruning uses a dedicated deterministic random stream
+  instead of replaying the empirical p-value stream.
+
 ## [1.1.0] - 2026-08-11
 
 ### Added
@@ -43,7 +53,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Bumped indirect dependency `idna` from `3.10` to `3.15`.
 - Bumped indirect dependency `pymdown-extensions` from `10.16.1` to `10.21.3`.
 
-[Unreleased]: https://github.com/OliverHennhoefer/nonconform/compare/v1.1.0...HEAD
+[Unreleased]: https://github.com/OliverHennhoefer/nonconform/compare/v1.1.1...HEAD
+[1.1.1]: https://github.com/OliverHennhoefer/nonconform/compare/v1.1.0...v1.1.1
 [1.1.0]: https://github.com/OliverHennhoefer/nonconform/compare/v1.0.2...v1.1.0
 [1.0.2]: https://github.com/OliverHennhoefer/nonconform/compare/v1.0.1...v1.0.2
 [1.0.1]: https://github.com/OliverHennhoefer/nonconform/compare/v1.0.0...v1.0.1

--- a/docs/source/user_guide/fdr_control.md
+++ b/docs/source/user_guide/fdr_control.md
@@ -59,6 +59,12 @@ detector.fit(X_train)
 mask = detector.select(X_test, alpha=0.05)
 ```
 
+Weighted detectors use classical `Empirical()` by default. Classical weighted
+p-values include tied calibration mass and are accepted by `select()`.
+Randomized empirical p-values are explicit opt-in estimators with
+marginal/asymptotic validity. The published finite-sample WCS theorem uses
+strict primary and auxiliary comparisons.
+
 For the weighted case with custom pruning:
 
 ```python
@@ -289,6 +295,13 @@ The ``pruning`` parameter controls the second-stage WCS pruning rule.
 ``DETERMINISTIC`` uses a fixed rule. ``HOMOGENEOUS`` and ``HETEROGENEOUS`` use
 shared or independent randomness. Set ``seed`` for reproducible randomized
 pruning decisions.
+
+The Jin--Candès finite-sample WCS construction uses strict primary and
+auxiliary comparisons. Classical and strict primary formulas agree when no
+calibration score ties the test score. With exact ties, the implementation uses
+conservative classical primary p-values; that variant is outside the theorem's
+stated scope. Seeded randomized pruning uses a deterministic stream distinct
+from the estimator's random stream.
 
 ## Available Methods
 

--- a/docs/source/user_guide/statistical_concepts.md
+++ b/docs/source/user_guide/statistical_concepts.md
@@ -32,7 +32,8 @@ reference population.
 **Classical vs. Randomized**:
 
 - `Empirical()` defaults to `tie_break="classical"`, which gives discrete
-  p-values in steps of $1/(n+1)$.
+  p-values in steps of $1/(n+1)$ and includes calibration scores tied with the
+  test score, giving deterministic conservative behavior.
 - Valid `tie_break` values are `"classical"` and `"randomized"` (or
   `TieBreakMode.CLASSICAL` / `TieBreakMode.RANDOMIZED`); `None` is invalid.
 - For smoother p-values, use `Empirical(tie_break="randomized")`.

--- a/docs/source/user_guide/weighted_conformal.md
+++ b/docs/source/user_guide/weighted_conformal.md
@@ -138,6 +138,11 @@ def weighted_p_value(test_score, calibration_scores, calibration_weights, test_w
     `Empirical(tie_break="randomized")`. With small calibration sets,
     randomized smoothing is less conservative than the classical formula and
     adds run-to-run variability; set a seed when reproducibility matters.
+    With detectors that produce many exactly tied scores (e.g. histogram-based
+    methods), the classical formula's resolution can collapse toward the
+    randomized formula's: on the SHUTTLE/HBOS setup used in
+    `tests/e2e/test_weighted_empirical.py`, both give 0 discoveries at
+    `alpha=0.2`.
 
 ## When to Use Weighted Conformal
 

--- a/docs/source/user_guide/weighted_conformal.md
+++ b/docs/source/user_guide/weighted_conformal.md
@@ -43,7 +43,20 @@ stable. You also need independent calibration/test samples and enough support
 overlap between feature distributions; when shift is too extreme, estimated
 density ratios become unstable and weighted conformal adjustment may fail.
 
-The weighted p-values provide per-hypothesis calibration under the paper's assumptions. For multiple simultaneous anomaly decisions, pair them with Weighted Conformalized Selection (WCS); this is the documented finite-sample FDR path under covariate shift [[Jin & Candès, 2023](#references)]. If the weights are learned rather than known, exactness depends on weight quality and the paper's estimated-weight bounds should be read as potential FDR inflation rather than an automatic exact guarantee.
+The weighted p-values provide per-hypothesis calibration under the relevant
+weighted-conformal assumptions. For multiple simultaneous decisions, pair them
+with Weighted Conformalized Selection (WCS). Jin & Candès (2023) prove
+finite-sample WCS control using strict primary and auxiliary score comparisons.
+The classical default agrees with the strict primary formula without relevant
+ties and is conservative when ties occur. The implementation accepts tied
+scores; this classical tied-score variant lies outside the theorem's stated
+scope. Randomized empirical estimation follows Eq. (4) and has
+marginal/asymptotic validity. The finite-sample WCS theorem uses the strict
+primary formula.
+
+If weights are learned rather than known, exactness depends on their quality.
+KDE/`Probabilistic` scoring is a model-based/asymptotic path, not the same
+finite-sample conformal result.
 
 `ConformalDetector(weight_estimator=...)` estimates importance weights by
 distinguishing calibration samples from the current test batch, then uses those
@@ -70,8 +83,8 @@ detector = ConformalDetector(
     seed=42,
 )
 
-# Fit on training data and get weighted p-values
-# By default, prediction refits the weight model for each batch
+# Fit on training data and get classical weighted empirical p-values.
+# By default, prediction refits the weight model for each batch.
 p_values = detector.fit(X_train).compute_p_values(X_test)
 ```
 
@@ -106,7 +119,24 @@ discipline, set `verify_prepared_batch_content=False` when constructing
 `ConformalDetector` to validate only batch size.
 
 ### 3. Weighted P-value Calculation
-The p-values are computed using weighted empirical distribution functions. By default, `nonconform` uses the classical (non-randomized) formula. The randomized variant [[Jin & Candès, 2023](#references)] handles ties more gracefully:
+The p-values are computed using weighted empirical distribution functions.
+Standalone `Empirical()` and `calculate_weighted_p_val()` use the deterministic
+classical formula by default, which includes calibration mass tied with the
+test score:
+
+```python
+# Classical deterministic discrete formula
+weighted_at_or_above = np.sum(
+    calibration_weights[calibration_scores >= test_score]
+)
+p_value = (weighted_at_or_above + test_weight) / (
+    np.sum(calibration_weights) + test_weight
+)
+```
+
+This is conservative for discrete scores and can have coarse resolution. The
+randomized variant [[Jin & Candès, 2023](#references)] handles ties and the
+test point's own mass by randomization:
 
 ```python
 # Randomized weighted p-value calculation (Jin & Candes 2023)
@@ -131,18 +161,21 @@ def weighted_p_value(test_score, calibration_scores, calibration_weights, test_w
 ```
 
 !!! info "Classical vs. Randomized"
-    By default, `Empirical()` uses `tie_break="classical"` (non-randomized
-    formula). Valid values are `"classical"` and `"randomized"` (or
-    `TieBreakMode.CLASSICAL` / `TieBreakMode.RANDOMIZED`). `None` is not valid.
-    For randomized smoothing as shown above, use
-    `Empirical(tie_break="randomized")`. With small calibration sets,
-    randomized smoothing is less conservative than the classical formula and
-    adds run-to-run variability; set a seed when reproducibility matters.
-    With detectors that produce many exactly tied scores (e.g. histogram-based
-    methods), the classical formula's resolution can collapse toward the
-    randomized formula's: on the SHUTTLE/HBOS setup used in
-    `tests/e2e/test_weighted_empirical.py`, both give 0 discoveries at
-    `alpha=0.2`.
+    `Empirical()` defaults to `tie_break="classical"` in weighted and
+    unweighted workflows. Valid values are `"classical"` and `"randomized"`
+    (or their `TieBreakMode` members); `None` is invalid. Randomization
+    interpolates tied calibration mass and the test point's own mass even when
+    no calibration score ties the test score. It removes the classical
+    positive resolution floor but adds variability; set a seed for
+    reproducibility.
+
+!!! warning "Discrete WCS guarantee scope"
+    Published finite-sample WCS uses strict comparisons in both its primary and
+    leave-one-out auxiliary formulas. Classical primary p-values coincide with
+    that formula when no relevant ties exist. For exact ties, the implementation
+    uses conservative classical primary p-values outside the theorem's stated
+    scope. Randomized Eq. (4) provides marginal/asymptotic validity and is
+    available explicitly.
 
 ## When to Use Weighted Conformal
 
@@ -565,10 +598,10 @@ cv_detector = ConformalDetector(
 ## Weighted Conformal Selection
 
 Weighted conformal p-values provide per-hypothesis calibration under covariate
-shift assumptions. To obtain finite-sample FDR control across many test points,
-combine them with Weighted Conformal Selection (WCS) under the independence,
-support-overlap, and weight-quality assumptions in Jin & Candès [[Jin & Candès,
-2023](#references)]:
+shift assumptions. For score configurations covered by the strict published
+construction, Weighted Conformal Selection (WCS) provides finite-sample FDR
+control under the independence, support-overlap, and weight-quality assumptions
+in Jin & Candès [[Jin & Candès, 2023](#references)]:
 
 ```python
 from nonconform.enums import Pruning

--- a/nonconform/__init__.py
+++ b/nonconform/__init__.py
@@ -43,7 +43,7 @@ Examples:
     ... )
 """
 
-__version__ = "1.1.0"
+__version__ = "1.1.1"
 __author__ = "Oliver Hennhoefer"
 __email__ = "oliver.hennhoefer@mail.de"
 

--- a/nonconform/detector.py
+++ b/nonconform/detector.py
@@ -45,6 +45,8 @@ if TYPE_CHECKING:
     from nonconform.resampling import BaseStrategy
     from nonconform.scoring import BaseEstimation
 
+_WCS_PRUNING_SEED_DOMAIN = 0x574353  # ASCII "WCS"
+
 
 def _safe_copy(arr: np.ndarray | None) -> np.ndarray | None:
     """Return a copy of array or None if None."""
@@ -54,6 +56,14 @@ def _safe_copy(arr: np.ndarray | None) -> np.ndarray | None:
 def _snapshot_param(value: Any) -> Any:
     """Return an immutable constructor-parameter snapshot."""
     return deepcopy(value)
+
+
+def _derive_wcs_pruning_seed(seed: int | None) -> int | None:
+    """Derive a deterministic WCS-pruning stream distinct from ``seed``."""
+    if seed is None:
+        return None
+    seed_sequence = np.random.SeedSequence([seed, _WCS_PRUNING_SEED_DOMAIN])
+    return int(seed_sequence.generate_state(1, dtype=np.uint64)[0])
 
 
 def _batch_signature(x: np.ndarray) -> tuple[tuple[int, ...], str, str]:
@@ -760,7 +770,7 @@ class ConformalDetector(BaseConformalDetector):
                 result=result,
                 alpha=alpha,
                 pruning=pruning,
-                seed=selection_seed,
+                seed=_derive_wcs_pruning_seed(selection_seed),
             )
         else:
             p_values = np.asarray(result.p_values, dtype=float)

--- a/nonconform/fdr.py
+++ b/nonconform/fdr.py
@@ -861,7 +861,12 @@ def _validate_pruning(pruning: Pruning) -> None:
 def _calib_weight_mass_strictly_above(
     calib_scores: np.ndarray, w_calib: np.ndarray, targets: np.ndarray
 ) -> np.ndarray:
-    """Compute weighted calibration mass strictly above each target score."""
+    """Compute WCS auxiliary calibration mass strictly above each target.
+
+    This strict comparison is part of WCS's leave-one-out self-consistency
+    construction. It is intentionally separate from the tie policy used for
+    the primary empirical p-values.
+    """
     order = np.argsort(calib_scores)
     sorted_scores = calib_scores[order]
     sorted_weights = w_calib[order]
@@ -1110,6 +1115,8 @@ def _run_wcs(
     if include_self_weight:
         sorted_test_idx = np.argsort(test_scores_arr, kind="mergesort")
         sorted_scores = test_scores_arr[sorted_test_idx]
+        # WCS auxiliary self-weight uses a strict score ordering; tied test
+        # scores are intentionally excluded independently of primary p-values.
         lt_cutoffs = np.searchsorted(sorted_scores, test_scores_arr, side="left")
     logger = get_logger("fdr")
     j_iterator = (

--- a/nonconform/scoring.py
+++ b/nonconform/scoring.py
@@ -97,8 +97,8 @@ class Empirical(BaseEstimation):
     """Classical empirical p-value estimation using discrete CDF.
 
     Computes p-values using deterministic tie handling by default. Optionally
-    supports randomized smoothing to eliminate the resolution floor caused by
-    discrete ties (Jin & Candes 2023).
+    supports randomized smoothing of tied calibration mass and the test point's
+    own mass, eliminating the classical resolution floor (Jin & Candes 2023).
 
     Args:
         tie_break: Tie-breaking strategy (`"classical"` or `"randomized"`).
@@ -309,7 +309,7 @@ def calculate_p_val(
     n_cal = len(calibration_set)
 
     if mode is TieBreakMode.CLASSICAL:
-        # Old formula: count >= (at or above)
+        # Deterministic discrete formula: count calibration scores >= score.
         ranks = n_cal - np.searchsorted(sorted_cal, scores, side="left")
         return (1.0 + ranks) / (1.0 + n_cal)
 
@@ -336,9 +336,19 @@ def calculate_weighted_p_val(
 ) -> np.ndarray:
     """Calculate weighted empirical p-values (standalone function).
 
-    Uses classical deterministic tie handling by default. Optionally supports
-    randomized smoothing to eliminate the resolution floor caused by discrete
-    ties (Jin & Candes 2023).
+    The default ``"classical"`` mode uses deterministic discrete tie handling:
+    calibration mass at or above the test score is included, together with the
+    test point's own weight. For calibration mass ``W_cal`` and test score
+    ``s`` with test weight ``w_test``, this is
+    ``(W_{>=}(s) + w_test) / (W_cal + w_test)``. This variant is conservative
+    for discrete scores and agrees with the unweighted classical formula when
+    all weights are one. Without calibration scores tied with ``s``, it equals
+    the strict deterministic formula used by Jin and Candes (2023).
+
+    The ``"randomized"`` mode uses the tie-safe weighted conformal formula
+    ``(W_{>}(s) + U * (W_{=}(s) + w_test)) / (W_cal + w_test)``, where
+    ``U`` is uniform on ``[0, 1]``. It avoids the discrete resolution floor and
+    interpolates both tied calibration mass and the test point's own mass.
 
     Args:
         scores: Test instance anomaly scores (1D array).
@@ -353,9 +363,10 @@ def calculate_weighted_p_val(
         Array of weighted p-values for each test instance.
 
     Note:
-        Including test_weights in the numerator/denominator implies a positive
-        lower bound of test_weights / (sum(calib_weights) + test_weights) when
-        there is no calibration mass above the test score.
+        Classical mode has the positive lower bound
+        ``test_weights / (sum(calib_weights) + test_weights)`` when no
+        calibration mass lies above the test score. Randomized mode has no such
+        positive floor because it multiplies the test point's mass by ``U``.
     """
     mode = _normalize_tie_break_mode(tie_break)
 
@@ -403,17 +414,17 @@ def calculate_weighted_p_val(
     right_idx = np.searchsorted(sorted_scores, scores, side="right")
 
     if mode is TieBreakMode.CLASSICAL:
-        weighted_greater = total_weight - cumulative_weights[left_idx]
-        numerator = weighted_greater + w_scores
+        weighted_at_or_above = total_weight - cumulative_weights[left_idx]
+        numerator = weighted_at_or_above + w_scores
     else:
-        weighted_greater = total_weight - cumulative_weights[right_idx]
+        weighted_strictly_above = total_weight - cumulative_weights[right_idx]
         weighted_equal = cumulative_weights[right_idx] - cumulative_weights[left_idx]
 
         if rng is None:
             rng = np.random.default_rng()
         u = rng.uniform(size=len(scores))
 
-        numerator = weighted_greater + (weighted_equal + w_scores) * u
+        numerator = weighted_strictly_above + (weighted_equal + w_scores) * u
 
     denominator = total_weight + w_scores
     return numerator / denominator

--- a/nonconform/scoring.py
+++ b/nonconform/scoring.py
@@ -403,7 +403,7 @@ def calculate_weighted_p_val(
     right_idx = np.searchsorted(sorted_scores, scores, side="right")
 
     if mode is TieBreakMode.CLASSICAL:
-        weighted_greater = total_weight - cumulative_weights[right_idx]
+        weighted_greater = total_weight - cumulative_weights[left_idx]
         numerator = weighted_greater + w_scores
     else:
         weighted_greater = total_weight - cumulative_weights[right_idx]

--- a/tests/e2e/test_weighted_empirical.py
+++ b/tests/e2e/test_weighted_empirical.py
@@ -33,14 +33,10 @@ class TestWeightedEmpirical:
     """
 
     def test_split(self):
-        """Test WCS with split conformal on SHUTTLE dataset (non-randomized).
+        """Test WCS with split conformal on SHUTTLE (non-randomized).
 
-        Note: HBOS produces heavily tied scores. With tied calibration mass
-        now counted for the test point (see calculate_weighted_p_val), the
-        classical p-values on this tie-heavy input collapse to the same
-        resolution as the randomized branch, giving 0 discoveries here. Use
-        tie_break="randomized" (test_split_randomized below) for a detector
-        whose scores tie this often.
+        HBOS produces heavily tied scores. Counting tied calibration mass makes
+        the classical p-values conservative, giving no discoveries here.
         """
         x_train, x_test, y_test = load(Dataset.SHUTTLE, setup=True, seed=1)
 

--- a/tests/e2e/test_weighted_empirical.py
+++ b/tests/e2e/test_weighted_empirical.py
@@ -35,8 +35,12 @@ class TestWeightedEmpirical:
     def test_split(self):
         """Test WCS with split conformal on SHUTTLE dataset (non-randomized).
 
-        Note: WCS may be conservative with limited calibration data,
-        resulting in fewer discoveries than standard BH.
+        Note: HBOS produces heavily tied scores. With tied calibration mass
+        now counted for the test point (see calculate_weighted_p_val), the
+        classical p-values on this tie-heavy input collapse to the same
+        resolution as the randomized branch, giving 0 discoveries here. Use
+        tie_break="randomized" (test_split_randomized below) for a detector
+        whose scores tie this often.
         """
         x_train, x_test, y_test = load(Dataset.SHUTTLE, setup=True, seed=1)
 
@@ -51,10 +55,10 @@ class TestWeightedEmpirical:
         ce.fit(x_train)
         decisions = ce.select(x_test, alpha=0.2)
         assert false_discovery_rate(y=y_test, y_hat=decisions) == pytest.approx(
-            0.145454545455, rel=0.0, abs=METRIC_ATOL
+            0.0, rel=0.0, abs=METRIC_ATOL
         )
         assert statistical_power(y=y_test, y_hat=decisions) == pytest.approx(
-            0.94, rel=0.0, abs=METRIC_ATOL
+            0.0, rel=0.0, abs=METRIC_ATOL
         )
 
     def test_split_randomized(self):

--- a/tests/unit/detection/test_conformal.py
+++ b/tests/unit/detection/test_conformal.py
@@ -10,7 +10,9 @@ from sklearn.svm import OneClassSVM
 
 from nonconform import ConformalDetector as _ConformalDetector
 from nonconform import JackknifeBootstrap, Split
+from nonconform.detector import _derive_wcs_pruning_seed
 from nonconform.enums import Pruning, ScorePolarity
+from nonconform.scoring import Empirical, calculate_weighted_p_val
 from nonconform.structures import AnomalyDetector, ConformalResult
 from nonconform.weighting import BaseWeightEstimator
 
@@ -148,6 +150,21 @@ class TestConformalDetectorInit:
         )
         assert detector is not None
         assert not detector.is_fitted
+
+    def test_empirical_default_is_classical_in_all_modes(self):
+        """Weighting does not change the public empirical default."""
+        weighted = ConformalDetector(
+            detector=MockDetector(),
+            strategy=Split(n_calib=0.2),
+            weight_estimator=CountingWeightEstimator(),
+        )
+        unweighted = ConformalDetector(
+            detector=MockDetector(), strategy=Split(n_calib=0.2)
+        )
+
+        for detector in (weighted, unweighted):
+            assert isinstance(detector.estimation, Empirical)
+            assert detector.estimation._tie_break.value == "classical"
 
     def test_init_with_seed(self):
         """Initialization with seed sets random state."""
@@ -933,17 +950,35 @@ class TestConformalDetectorWeightedPreparation:
         assert len(selected) == len(x_test)
         assert call_args["alpha"] == 0.1
         assert call_args["pruning"] is Pruning.HETEROGENEOUS
-        assert call_args["seed"] == 7
+        assert call_args["seed"] == _derive_wcs_pruning_seed(7)
+
+    def test_select_accepts_classical_empirical_wcs(self, sample_data):
+        """Weighted select accepts classical empirical p-values."""
+        x_train, x_test = sample_data
+        detector = ConformalDetector(
+            detector=MockDetector(np.arange(100, dtype=float)),
+            strategy=Split(n_calib=0.2),
+            estimation=Empirical(tie_break="classical"),
+            weight_estimator=CountingWeightEstimator(),
+            seed=42,
+        )
+        detector.fit(x_train)
+
+        selected = detector.select(x_test, alpha=0.1)
+
+        assert selected.shape == (len(x_test),)
+        assert selected.dtype == bool
 
     def test_select_uses_detector_seed_by_default_in_weighted_mode(
         self, sample_data, monkeypatch
     ):
-        """Weighted select() defaults pruning seed to detector seed."""
+        """Weighted select derives a stable pruning stream from detector seed."""
         x_train, x_test = sample_data
         rng = np.random.default_rng(42)
         detector = ConformalDetector(
             detector=MockDetector(rng.standard_normal(100)),
             strategy=Split(n_calib=0.2),
+            estimation=Empirical(tie_break="randomized"),
             weight_estimator=CountingWeightEstimator(),
             seed=123,
         )
@@ -960,13 +995,23 @@ class TestConformalDetectorWeightedPreparation:
         ) -> np.ndarray:
             captured_seed["value"] = seed
             assert result is not None and result.p_values is not None
+            expected = calculate_weighted_p_val(
+                result.test_scores,
+                result.calib_scores,
+                result.test_weights,
+                result.calib_weights,
+                tie_break="randomized",
+                rng=np.random.default_rng(123),
+            )
+            np.testing.assert_allclose(result.p_values, expected)
             return np.zeros(len(result.p_values), dtype=bool)
 
         monkeypatch.setattr(
             "nonconform.fdr.weighted_false_discovery_control", fake_weighted_fdr
         )
         _ = detector.select(x_test, alpha=0.1, pruning=Pruning.HOMOGENEOUS)
-        assert captured_seed["value"] == 123
+        assert captured_seed["value"] == _derive_wcs_pruning_seed(123)
+        assert captured_seed["value"] != 123
 
 
 class TestConformalDetectorSklearnParams:

--- a/tests/unit/utils/stat/test_statistical_core.py
+++ b/tests/unit/utils/stat/test_statistical_core.py
@@ -93,6 +93,105 @@ class TestWeightedPValueCalculation:
         np.testing.assert_almost_equal(p_values[0], expected)
 
 
+class TestWeightedTieSemantics:
+    def test_classical_includes_weighted_calibration_ties(self):
+        test_scores = np.array([2.0])
+        calib_scores = np.array([1.0, 2.0, 2.0, 3.0])
+        test_weights = np.array([5.0])
+        calib_weights = np.array([1.0, 2.0, 3.0, 4.0])
+
+        p_values = calculate_weighted_p_val(
+            scores=test_scores,
+            calibration_set=calib_scores,
+            test_weights=test_weights,
+            calib_weights=calib_weights,
+            tie_break="classical",
+        )
+
+        # At-or-above mass is 2 + 3 + 4. A strict comparison yields (4 + 5) / 15.
+        expected = (2.0 + 3.0 + 4.0 + 5.0) / 15.0
+        strict_excluding_ties = (4.0 + 5.0) / 15.0
+        np.testing.assert_allclose(p_values, [expected])
+        assert p_values[0] > strict_excluding_ties
+
+    def test_uniform_weighted_classical_matches_unweighted_on_ties(self):
+        test_scores = np.array([2.0, 3.0, 2.0])
+        calib_scores = np.array([1.0, 2.0, 2.0, 3.0])
+
+        weighted = calculate_weighted_p_val(
+            scores=test_scores,
+            calibration_set=calib_scores,
+            test_weights=np.ones(len(test_scores)),
+            calib_weights=np.ones(len(calib_scores)),
+            tie_break="classical",
+        )
+        unweighted = calculate_p_val(test_scores, calib_scores, tie_break="classical")
+
+        np.testing.assert_allclose(weighted, unweighted)
+
+    def test_classical_matches_strict_formula_without_ties(self):
+        test_scores = np.array([2.5])
+        calib_scores = np.array([1.0, 2.0, 3.0, 4.0])
+        test_weights = np.array([2.0])
+        calib_weights = np.array([1.0, 2.0, 3.0, 4.0])
+
+        actual = calculate_weighted_p_val(
+            scores=test_scores,
+            calibration_set=calib_scores,
+            test_weights=test_weights,
+            calib_weights=calib_weights,
+            tie_break="classical",
+        )
+
+        strictly_above = 3.0 + 4.0
+        expected = (strictly_above + test_weights[0]) / (
+            calib_weights.sum() + test_weights[0]
+        )
+        np.testing.assert_allclose(actual, [expected])
+
+    def test_randomized_partial_tie_formula(self):
+        test_scores = np.array([2.0])
+        calib_scores = np.array([1.0, 2.0, 2.0, 3.0])
+        test_weights = np.array([5.0])
+        calib_weights = np.array([1.0, 2.0, 3.0, 4.0])
+        seed = 123
+
+        expected_rng = np.random.default_rng(seed)
+        u = expected_rng.uniform(size=1)[0]
+        expected = (4.0 + (2.0 + 3.0 + 5.0) * u) / 15.0
+        actual = calculate_weighted_p_val(
+            scores=test_scores,
+            calibration_set=calib_scores,
+            test_weights=test_weights,
+            calib_weights=calib_weights,
+            tie_break="randomized",
+            rng=np.random.default_rng(seed),
+        )
+
+        np.testing.assert_allclose(actual, [expected])
+
+    def test_randomized_all_ties_uses_uniform_tie_mass(self):
+        n_calib = 19
+        n_test = 20
+        test_scores = np.full(n_test, 5.0)
+        calib_scores = np.full(n_calib, 5.0)
+        test_weights = np.ones(n_test)
+        calib_weights = np.ones(n_calib)
+        seed = 456
+
+        expected = np.random.default_rng(seed).uniform(size=n_test)
+        actual = calculate_weighted_p_val(
+            scores=test_scores,
+            calibration_set=calib_scores,
+            test_weights=test_weights,
+            calib_weights=calib_weights,
+            tie_break="randomized",
+            rng=np.random.default_rng(seed),
+        )
+
+        np.testing.assert_allclose(actual, expected)
+
+
 class TestPValueRange:
     def test_minimum_p_value_greater_than_zero(self, sample_scores):
         test_scores, calib_scores = sample_scores(n_test=20, n_calib=100)

--- a/tests/unit/utils/stat/test_weighted_fdr_edge.py
+++ b/tests/unit/utils/stat/test_weighted_fdr_edge.py
@@ -2,7 +2,9 @@ import numpy as np
 import pytest
 from scipy.stats import false_discovery_control
 
+from nonconform.enums import Pruning
 from nonconform.fdr import (
+    _calib_weight_mass_strictly_above,
     weighted_false_discovery_control,
     weighted_false_discovery_control_from_arrays,
 )
@@ -32,6 +34,94 @@ def _wcs_from_empirical_scores(
         calib_weights=calib_weights,
         alpha=alpha,
     )
+
+
+class TestDiscreteTieBehavior:
+    def test_all_ties_contrast_classical_and_strict_primary_inputs(self):
+        n_calib = 19
+        n_test = 20
+        calib_scores = np.full(n_calib, 5.0)
+        test_scores = np.full(n_test, 5.0)
+        calib_weights = np.ones(n_calib)
+        test_weights = np.ones(n_test)
+
+        classical_p_values = calculate_weighted_p_val(
+            scores=test_scores,
+            calibration_set=calib_scores,
+            test_weights=test_weights,
+            calib_weights=calib_weights,
+            tie_break="classical",
+        )
+        np.testing.assert_array_equal(classical_p_values, np.ones(n_test))
+
+        # The explicit-array API consumes precomputed p-values without
+        # provenance checks. Classical all-ties p-values equal one.
+        for pruning in Pruning:
+            classical_discoveries = weighted_false_discovery_control_from_arrays(
+                p_values=classical_p_values,
+                test_scores=test_scores,
+                calib_scores=calib_scores,
+                test_weights=test_weights,
+                calib_weights=calib_weights,
+                alpha=0.1,
+                pruning=pruning,
+                seed=42,
+            )
+            assert not np.any(classical_discoveries)
+
+        # A strict primary p-value is 1 / (n_calib + 1).
+        # In this all-null example it makes the current array-level WCS path
+        # select all test points, demonstrating why the classical formula must
+        # retain tied calibration mass.
+        strict_p_values = np.full(n_test, 1.0 / (n_calib + 1))
+        strict_discoveries = weighted_false_discovery_control_from_arrays(
+            p_values=strict_p_values,
+            test_scores=test_scores,
+            calib_scores=calib_scores,
+            test_weights=test_weights,
+            calib_weights=calib_weights,
+            alpha=0.1,
+            pruning=Pruning.DETERMINISTIC,
+        )
+        assert np.all(strict_discoveries)
+
+    def test_wcs_auxiliary_mass_is_strictly_above(self):
+        calib_scores = np.array([1.0, 2.0, 2.0, 3.0])
+        calib_weights = np.array([1.0, 2.0, 3.0, 4.0])
+        targets = np.array([1.0, 2.0, 3.0])
+
+        mass = _calib_weight_mass_strictly_above(calib_scores, calib_weights, targets)
+
+        np.testing.assert_allclose(mass, [9.0, 4.0, 0.0])
+
+    def test_result_bundle_accepts_classical_empirical_policy(self, conformal_result):
+        result = conformal_result(n_test=5, n_calib=20)
+        result.metadata = {
+            "nonconform": {
+                "strategy": "Split",
+                "estimation": "Empirical",
+                "weighted": True,
+            },
+            "tie_break": "classical",
+        }
+
+        discoveries = weighted_false_discovery_control(result=result, alpha=0.1)
+        assert discoveries.shape == (5,)
+
+    def test_result_bundle_accepts_custom_estimator_without_tie_metadata(
+        self, conformal_result
+    ):
+        result = conformal_result(n_test=5, n_calib=20)
+        result.metadata = {
+            "nonconform": {
+                "strategy": "Split",
+                "estimation": "CustomEstimation",
+                "weighted": True,
+            },
+        }
+
+        discoveries = weighted_false_discovery_control(result=result, alpha=0.1)
+        assert discoveries.shape == (5,)
 
 
 class TestNoDiscoveries:


### PR DESCRIPTION
Relates to #41 — opening this alongside the issue since it's a small,
concrete change to discuss, not because I'm sure it's the intended fix.
See #41 for the full question: commit `0cb90d574a` made the strict form
here deliberately, and Jin & Candès' eq. (5) justifies a strict form under
almost-surely-distinct scores, so this may not be wanted as-is.

## What this changes

`calculate_weighted_p_val`'s `TieBreakMode.CLASSICAL` branch used
`cumulative_weights[right_idx]`, which excludes calibration mass tied with
the test score. `left_idx` is already computed one line above and used by
the `else` (randomized) branch; this uses it in the classical branch too,
so tied mass is counted the same way `calculate_p_val`'s classical branch
counts it (and matches eq. (1) of arXiv:2603.23205, the paper's
deterministic estimator).

```python
if mode is TieBreakMode.CLASSICAL:
    weighted_greater = total_weight - cumulative_weights[left_idx]   # was right_idx
    numerator = weighted_greater + w_scores
```

## Not a one-liner: one e2e test's expected values flip

`tests/e2e/test_weighted_empirical.py::test_split` runs
`ConformalDetector(detector=HBOS(), ..., estimation=Empirical(tie_break="classical"), weight_estimator=logistic_weight_estimator())`
on the SHUTTLE dataset. HBOS's histogram scores tie heavily. With this
change, FDR goes from 0.1455 to 0 and power from 0.94 to 0 (110
discoveries to 0) on that test, because the classical formula's
resolution collapses to the same floor `test_split_randomized` already
hits on the same dataset. I've updated that test's expected values and
docstring to describe why, and added a short note to
`docs/source/user_guide/weighted_conformal.md`'s classical-vs-randomized
box pointing at the same collapse for tie-heavy detectors. If a
tie-detecting warning (or steering tie-heavy callers toward
`tie_break="randomized"`) is a better fix than silently changing the
classical branch's output, I can rework this PR around that instead — I
picked the direct fix mainly to make the branch disagreement in #41
concrete.

## Verified

```python
>>> import numpy as np
>>> from nonconform.scoring import Empirical
>>> n = 19
>>> cal = np.full(n, 5.0); test = np.array([5.0])
>>> w_cal = np.ones(n); w_test = np.array([1.0])
>>> est = Empirical()
>>> est.compute_p_values(test, cal)
array([1.])
>>> est.compute_p_values(test, cal, weights=(w_cal, w_test))   # was [0.05] before this change
array([1.])
```

`uv run ruff format .` and `uv run ruff check .` are clean on the changed
files. Full `uv run pytest` (867 passed) plus the one intentionally
updated test.